### PR TITLE
Fix: Toggle switches don't have a background when unchecked

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -1342,9 +1342,8 @@ input[type="checkbox"] {
 }
 
 input[type="checkbox"] + span {
-   background: rgba(85, 85, 85, 0);
+   background: rgb(85, 85, 85);
    border-radius: 10px;
-   box-shadow: 0 2px 3px 0 rgba(0, 0, 0, 0);
    display: inline-block;
    height: 20px;
    margin: 2px 2px;


### PR DESCRIPTION
This pr fixes toggle switches not having a background when unchecked.

Current:
![image](https://github.com/user-attachments/assets/0a143a67-2e94-4947-ae90-b12ea7bedd77)
After pr:
![image](https://github.com/user-attachments/assets/ae7e79a0-dd5b-47d8-a7a2-8c8c42e9be22)