### PR TITLE
Fix Wrong Font On Certain Browsers

### DIFF
--- a/css/font.css
+++ b/css/font.css
@@ -7,15 +7,6 @@
 }
 
 @font-face {
-  font-family: 'Comfortaa';
-  font-style: normal;
-  font-weight: 400;
-  font-display: swap;
-  src: url('https://fonts.googleapis.com/css2?family=Comfortaa:wght@300..700&display=swap.woff2') format('woff2');
-  unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
-}
-
-@font-face {
   font-family: 'fontello';
   font-style: normal;
   font-weight: normal;

--- a/css/main.css
+++ b/css/main.css
@@ -9,15 +9,6 @@
  }
  
  @font-face {
-   font-family: 'Comfortaa';
-   font-style: normal;
-   font-weight: 400;
-   font-display: swap;
-   src: url('https://fonts.googleapis.com/css2?family=Comfortaa:wght@300..700&display=swap.woff2') format('woff2');
-   unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
- }
- 
- @font-face {
    font-family: 'fontello';
    font-style: normal;
    font-weight: normal;


### PR DESCRIPTION
The font-face rules for Comfortaa were misconfigured as the src pointed to a stylesheet, not a font file. Regardless, they should be removed since the HTML heads already have 

```html
<link href="https://fonts.googleapis.com/css2?family=Comfortaa:wght@300..700&display=swap" rel="stylesheet">
``` 
which will pull in the correct font-face rules.

I've tested this fix on Chrome and Edge.